### PR TITLE
fix paths of dir with mult files

### DIFF
--- a/pages/admin/contact.json
+++ b/pages/admin/contact.json
@@ -1,0 +1,4 @@
+{
+    "template":"about",
+    "title":"Contact Us"
+}

--- a/src/App/Export/ExportService.php
+++ b/src/App/Export/ExportService.php
@@ -31,13 +31,15 @@ class ExportService
         
         if (!is_dir($pageDir)) {
             mkdir($pageDir);
-            $pageDir = $pageDir.'/';
         }
+
+        if (substr($pageDir, -1)!=='/') $pageDir = $pageDir.'/';
 
         $fileExt  = (AppSettings::build()->exportPageWithoutHTMLExtension() === true) ? '' : '.html';
         $filePath = $pageDir.$this->PageController->getPageName().$fileExt;
 
         file_put_contents($filePath,$this->PageController->getPageHtml());
+        
     }
 
     public function pageAssets(){


### PR DESCRIPTION
- Fixed an issue in the export service wherein when there are multiple files within a directory, the path does not map correctly. 
- For example, when there are 2 files in the pages/admin folder named users.json and products.json, only one gets the correct export path, which is dist/admin /users.html, while the other becomes dist/adminproducts.html